### PR TITLE
Make Polygon work correctly with NumPy arrays.

### DIFF
--- a/polygon.py
+++ b/polygon.py
@@ -38,7 +38,12 @@ def sign(x):
     Return 1 if x is positive, -1 if it's negative, and 0 if it's zero.
 
     """
-    return (x > 0) - (x < 0)
+    if x > 0:
+        return 1
+    elif x < 0:
+        return -1
+    else:
+        return 0
 
 
 def vertex_sign(P, O):
@@ -80,7 +85,11 @@ class Polygon(object):
 
         """
         points = self.vertex_positions
-        return zip(points, points[1:] + points[:1])
+        first_point = previous_point = points[0]
+        for point in points[1:]:
+            yield previous_point, point
+            previous_point = point
+        yield previous_point, first_point
 
     def area(self):
         """

--- a/test_polygon.py
+++ b/test_polygon.py
@@ -8,6 +8,13 @@ if sys.version_info >= (2, 7):
 else:
     import unittest2 as unittest
 
+try:
+    import numpy
+except ImportError:
+    NUMPY_AVAILABLE = False
+else:
+    NUMPY_AVAILABLE = True
+
 from polygon import Polygon
 
 
@@ -124,3 +131,20 @@ class TestPolygon(unittest.TestCase):
             else:
                 with self.assertRaises(ValueError):
                     aitch.winding_number(point)
+
+    @unittest.skipUnless(NUMPY_AVAILABLE, "Test requires NumPy")
+    def test_numpy_compatibility(self):
+        square = Polygon(
+            vertex_positions=numpy.array(
+                [
+                    [1.0, -1.0],
+                    [1.0, 1.0],
+                    [-1.0, 1.0],
+                    [-1.0, -1.0],
+                ],
+                dtype=numpy.float64,
+            )
+        )
+        origin = numpy.array([0.0, 0.0], dtype=numpy.float64)
+        self.assertEqual(square.winding_number(origin), 1)
+        self.assertEqual(square.area(), 4.0)


### PR DESCRIPTION
Similar to #2 and #3, ensure that the `Polygon` class works correctly when vertices are given in a NumPy array rather than a list of lists (or tuples).