### PR TITLE
Drop support for Python 2.6; update Python versions in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - 2.7
   - 3.5
   - 3.6
-  - 3.7
   - pypy
 script:
   - python -m unittest discover -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 3.7
   - pypy
 script:
-  - python -m unittest discover -v; fi
+  - python -m unittest discover -v
 notifications:
   email:
     - dickinsm@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: python
 python:
-  - 2.6
   - 2.7
-  - 3.2
-  - 3.3
-  - 3.4
+  - 3.5
+  - 3.6
+  - 3.7
   - pypy
-install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then unit2 discover -v; else python -m unittest discover -v; fi
+  - python -m unittest discover -v; fi
 notifications:
   email:
     - dickinsm@gmail.com

--- a/test_polygon.py
+++ b/test_polygon.py
@@ -2,11 +2,7 @@
 Tests for Polygon.winding_number.
 
 """
-import sys
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    import unittest2 as unittest
+import unittest
 
 from polygon import Polygon
 

--- a/test_polyhedron.py
+++ b/test_polyhedron.py
@@ -2,11 +2,7 @@
 Tests for Polyhedron winding number calculation.
 
 """
-import sys
-if sys.version_info >= (2, 7):
-    import unittest
-else:
-    import unittest2 as unittest
+import unittest
 
 try:
     import numpy


### PR DESCRIPTION
Here we drop support for the ancient Python 2.6 version, which removes the need for `unittest2` for testing.

We also adjust the Python versions in the Travis CI configuration, dropping Python 3 versions earlier than Python 3.5.

I have a suspicion that Travis CI may not yet support Python 3.7. We'll see.